### PR TITLE
Add package target to annotation. Fix package-info.java targeting

### DIFF
--- a/src/forgeAPI/java/net/minecraftforge/api/distmarker/OnlyIn.java
+++ b/src/forgeAPI/java/net/minecraftforge/api/distmarker/OnlyIn.java
@@ -42,9 +42,11 @@ import java.lang.annotation.Target;
  * as the initializer is a separate piece of code to the actual field declaration, and will not be able to find
  * it's field on the wrong side.
  *
+ * Note, when applied on a package-info.java, this only applies to the package-info.java file itself.
+ * It is a reasonable assumption that the whole package will also be restricted to that distribution, but not a requirement.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
 @Repeatable(OnlyIns.class)
 public @interface OnlyIn
 {

--- a/src/forgeAPI/java/net/minecraftforge/api/distmarker/OnlyIn.java
+++ b/src/forgeAPI/java/net/minecraftforge/api/distmarker/OnlyIn.java
@@ -42,11 +42,14 @@ import java.lang.annotation.Target;
  * as the initializer is a separate piece of code to the actual field declaration, and will not be able to find
  * it's field on the wrong side.
  *
- * Note, when applied on a package-info.java, this only applies to the package-info.java file itself.
+ * When applied on a package, this only applies to the package class file itself.
  * It is a reasonable assumption that the whole package will also be restricted to that distribution, but not a requirement.
+ *
+ * When applied on an annotation, this only applies to the annotation class itself, not any members that are annotated with it.
+ *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE})
 @Repeatable(OnlyIns.class)
 public @interface OnlyIn
 {


### PR DESCRIPTION
pretty straightforward. Not sure if this is useful to apply to the other annotations.
tested in mcp_config