### PR TITLE
Include annotations in the non-shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ java {
 jar {
     manifest.attributes('Main-Class': 'net.minecraftforge.mergetool.ConsoleMerger')
     manifest.attributes('Implementation-Version': project.version)
+    from sourceSets.cpwFML.output
+    from sourceSets.forgeFML.output
+    from sourceSets.forgeAPI.output
 }
 shadowJar {
     classifier 'fatjar'


### PR DESCRIPTION
This allows running mergetool via its API, as was possible
before ac071b725d90442294dbdca1d04167f2e8abbd8a

Given the sources for these annotations are manually added to 
the sources jar already and the jar content change was not mentioned
in the PR, this appears to be an oversight from the original restructuring.