### PR TITLE
Add API Automatic Module Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ task forgeFML(type: Jar) {
     from sourceSets.forgeFML.output
 }
 task forgeAPI(type: Jar) {
+    manifest.attributes('Automatic-Module-Name': 'net.minecraftforge.mergetool.api')
     classifier 'api'
     from sourceSets.forgeAPI.output
 }


### PR DESCRIPTION
Force the automatic module name of the api jar to be `net.minecraftforge.mergetool.api`.

Fixes an issues where the derived names at compile time and runtime differ in a forge dev environment - javac derives `mergetool`, while SecureJarHandler derives `mergetool.api`, resulting in a missing dependency error that leads to a crash.