### PR TITLE
Added whitelist/blacklist support

### DIFF
--- a/src/main/java/net/minecraftforge/mergetool/ConsoleMerger.java
+++ b/src/main/java/net/minecraftforge/mergetool/ConsoleMerger.java
@@ -99,6 +99,8 @@ public class ConsoleMerger
         OptionSpec<Void> data = parser.accepts("keep-data");
         OptionSpec<Void> meta = parser.accepts("keep-meta");
         OptionSpec<AnnotationVersion> anno = parser.accepts("ann").withOptionalArg().ofType(AnnotationVersion.class).withValuesConvertedBy(AnnotationReader).defaultsTo(AnnotationVersion.API);
+        OptionSpec<String> whitelist = parser.accepts("whitelist").withOptionalArg();
+        OptionSpec<String> blacklist = parser.accepts("blacklist").withOptionalArg();
 
         try
         {
@@ -121,6 +123,13 @@ public class ConsoleMerger
 
             if (options.has(meta))
                 merge.keepMeta();
+
+            if (options.has(whitelist))
+                options.valuesOf(whitelist).forEach(merge::whitelist);
+
+            if (options.has(blacklist)) {
+                options.valuesOf(blacklist).forEach(merge::blacklist);
+            }
 
             try
             {

--- a/src/main/java/net/minecraftforge/mergetool/ConsoleMerger.java
+++ b/src/main/java/net/minecraftforge/mergetool/ConsoleMerger.java
@@ -101,6 +101,8 @@ public class ConsoleMerger
         OptionSpec<AnnotationVersion> anno = parser.accepts("ann").withOptionalArg().ofType(AnnotationVersion.class).withValuesConvertedBy(AnnotationReader).defaultsTo(AnnotationVersion.API);
         OptionSpec<String> whitelist = parser.accepts("whitelist").withOptionalArg();
         OptionSpec<String> blacklist = parser.accepts("blacklist").withOptionalArg();
+        OptionSpec<File> clientMapping = parser.accepts("clientMapping").withOptionalArg().ofType(File.class);
+        OptionSpec<File> serverMapping = parser.accepts("serverMapping").withOptionalArg().ofType(File.class);
 
         try
         {
@@ -127,9 +129,14 @@ public class ConsoleMerger
             if (options.has(whitelist))
                 options.valuesOf(whitelist).forEach(merge::whitelist);
 
-            if (options.has(blacklist)) {
+            if (options.has(blacklist))
                 options.valuesOf(blacklist).forEach(merge::blacklist);
-            }
+
+            if (options.has(clientMapping))
+                merge.clientMapping(options.valueOf(clientMapping));
+
+            if (options.has(serverMapping))
+                merge.serverMapping(options.valueOf(serverMapping));
 
             try
             {

--- a/src/main/java/net/minecraftforge/mergetool/Merger.java
+++ b/src/main/java/net/minecraftforge/mergetool/Merger.java
@@ -63,6 +63,7 @@ public class Merger
     private FieldName FIELD = new FieldName();
     private MethodDesc METHOD = new MethodDesc();
     private HashSet<String> whitelist = new HashSet<>();
+    private HashSet<String> blacklist = new HashSet<>();
     private boolean copyData = false;
     private boolean keepMeta = false;
 
@@ -83,6 +84,12 @@ public class Merger
     public Merger whitelist(String file)
     {
         this.whitelist.add(file);
+        return this;
+    }
+
+    public Merger blacklist(String file)
+    {
+        this.blacklist.add(file);
         return this;
     }
 
@@ -125,7 +132,10 @@ public class Merger
             {
                 String name = entry.getKey();
 
-                if (!this.whitelist.isEmpty() && !this.whitelist.contains(name))
+                if (!this.whitelist.isEmpty() && this.whitelist.stream().noneMatch(name::contains))
+                    continue;
+
+                if (!this.blacklist.isEmpty() && this.blacklist.stream().anyMatch(name::contains))
                     continue;
 
                 ZipEntry cEntry = entry.getValue();
@@ -160,7 +170,10 @@ public class Merger
 
             for (Entry<String, ZipEntry> entry : sClasses.entrySet())
             {
-                if (!this.whitelist.isEmpty() && !this.whitelist.contains(entry.getKey()))
+                if (!this.whitelist.isEmpty() && this.whitelist.stream().noneMatch(entry.getKey()::contains))
+                    continue;
+
+                if (!this.blacklist.isEmpty() && this.blacklist.stream().anyMatch(entry.getKey()::contains))
                     continue;
 
                 if (DEBUG)


### PR DESCRIPTION
Whitelist stuff wasn't implemented with the console main method, added support for it, along with adding a blacklist (which is probably more useful).

Predominantly used for older type of jars (such as one from 1.12.2) where all the libraries weren't separated and were all jumbled in the server jar.

Whitelist/blacklist now act as a contains match rather than an exact match.